### PR TITLE
Fix SCSV detection

### DIFF
--- a/sslscan/module/rating/builtin.py
+++ b/sslscan/module/rating/builtin.py
@@ -83,5 +83,14 @@ class BuiltIn_0_5(BaseRating):
             )
         )
 
+        self.add_rule(
+            RatingRule(
+                "server.security.scsv",
+                rules=[
+                    lambda v, i, kb: 1 if v is True else None
+                ]
+            )
+        )
+
 
 modules.register(BuiltIn_0_5)

--- a/sslscan/module/report/terminal.py
+++ b/sslscan/module/report/terminal.py
@@ -426,7 +426,7 @@ class Terminal(BaseReport):
             )
             tmp_value = "-"
             if scsv_supported is None:
-                tmp_value = "unkown"
+                tmp_value = "unknown"
             elif scsv_supported is True:
                 tmp_value = "supported"
             elif scsv_supported is False:

--- a/sslscan/module/scan/__init__.py
+++ b/sslscan/module/scan/__init__.py
@@ -665,11 +665,11 @@ class BaseScan(BaseModule):
                 record = conn_tls.pop_record()
                 self.parse_tls_server_records_hooks.call(record)
 
+                records.append(record)
                 if isinstance(record, Alert):
                     if record.level == 2:
                         return records
 
-                records.append(record)
                 if stop_condition(record, records):
                     run = False
 


### PR DESCRIPTION
Previously, using `--scan=server.scsv` caused pysslscan to abort. This commit should fix the issues with SCSV detection.
